### PR TITLE
Open port 32400 to allow media server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,8 @@ services:
     container_name: plex
     restart: unless-stopped
     network_mode: host
+    ports:
+      - 32400:32400
     env_file:
       - ./config/plex/env
     volumes:


### PR DESCRIPTION
Previously, media server did not seem to be accessible from outside of the docker container. This PR aims to allow the server to be more than just a glorified plex web client by opening the port